### PR TITLE
implements option to omit prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,8 @@
 A node.js-based command line tool for batch renaming files, intended to be used as part of a data-merge workflow
 
 ### Background
-This tool is designed to be used in conjunction with the data-merge workflow in Adobe InDesign for templated bulk production of graphic assets, such as banner ads, social media post series, etc. It takes a folder of images and renames them based on the provided data files. 
+
+This tool is designed to be used in conjunction with the data-merge workflow in Adobe InDesign for templated bulk production of graphic assets, such as banner ads, social media post series, etc. It takes a folder of images and renames them based on the provided data files.
 
 ### Requirements
 
@@ -25,11 +26,11 @@ The package directory includes several folders:
 
 To use this tool, type `node index.js` or `node .` in the repository directory.
 The tool will prompt for the following parameters:
+
 - current base file name: the current
 - prefix: a short identifier that is prepended to each file name.
 - asset types CSV: a single-column list of file dimensions/asset types
 - batch names CSV: a single-column list of unique identifiers for each batch of asset
-
 
 ### Feature Roadmap
 
@@ -42,6 +43,6 @@ The tool will prompt for the following parameters:
 - [ ] add separate src and output folders
 - [ ] add option to move assets into individual folders by group
 - [ ] implement a way to clean up the imported CSV files to remove empty lines
-- [ ] add option to omit prefix parameter
+- [x] add option to omit prefix parameter (added in v1.2.0)
 - [ ] allow tool to work with file types other than JPG
 - [ ] auto suggest base filename from /img directory contents

--- a/index.js
+++ b/index.js
@@ -3,6 +3,7 @@ const { parse } = require("csv-parse/sync");
 const prompt = require("prompt-sync")();
 const { path } = require("path");
 // function declarations:
+
 /**
  * make sure a filename has the correct extension, and add it if it doesn't
  * @param {string} fileName - The filename/path.
@@ -40,7 +41,7 @@ const promptCSVFile = (message) => {
   const fileList = fs.readdirSync("./csv/", { withFileTypes: true });
   const fileNames = [];
   fileList.forEach((item) => {
-    if (item.isFile()) {
+    if (item.isFile() && item.name.includes(".csv")) {
       fileNames.push(item.name);
     }
   });

--- a/index.js
+++ b/index.js
@@ -61,18 +61,18 @@ const promptCSVFile = (message) => {
   }
 };
 
-promptCSVFile("TEST: select a file!");
-
 console.log("welcome to batch-rename");
 console.log("you should have:");
 console.log("1) assets in /img folder named as baseName_(1,2,3).jpg");
 console.log("2) csv file in /csv folder with a list of output file names");
 console.log("3) csv file in /csv folder with list of input file names");
 let baseName = prompt("current base file name (default is asset) ", "asset");
-let newBaseName = prompt(
-  "new base file name (ie TS22, SM22, OL22, default is TS22) ",
-  "TS22"
+let newPrefix = prompt(
+  "new prefix (ie TS22, SM22, OL22) or leave blank to omit "
 );
+if (newPrefix.length > 0) {
+  newPrefix = newPrefix + "_";
+}
 //ask for filenames
 let inputFilePath = promptCSVFile(
   "Choose a CSV file containing the list of asset types."
@@ -109,7 +109,7 @@ try {
 outputNameArray.forEach((outputItem, outputIndex) => {
   fileNameArray.forEach((inputItem, inputIndex) => {
     let curIndex = outputIndex * multiplier + inputIndex + 1;
-    let newFilename = `./img/${newBaseName}_${outputItem}_${inputItem}.jpg`;
+    let newFilename = `./img/${newPrefix}${outputItem}_${inputItem}.jpg`;
     let oldFilename = `./img/${baseName}_${curIndex}.jpg`;
 
     try {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "batch-rename",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "a simple tool to batch-rename files following a predefined schema",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
This PR adds the option for the user to leave the prefix field blank. If a prefix is provided, it is prepended to the file names with an underscore as a separator. If one is not provided, it omits the underscore separator.